### PR TITLE
(1.20.1 Forge) Fix Xtone Tile drop nothing

### DIFF
--- a/src/main/resources/data/xtonesreworked/loot_tables/blocks/xtone_tile.json
+++ b/src/main/resources/data/xtonesreworked/loot_tables/blocks/xtone_tile.json
@@ -1,0 +1,14 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "xtonesreworked:xtone_tile"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
(1.20.1 Forge) Fix Xtone Tile drop nothing when mining right tools